### PR TITLE
Support Windows usage of the `echoctl` tool

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,11 +18,12 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     goarch:
       - amd64
       - arm64
     ldflags:
-      - -s -w -X main.Version={{.Version}} -X main.GitCommit={{.Commit}} -X main.BuildDate={{.Date}}
+      - -s -w -X github.com/ygelfand/echolocal/internal/layout.Version={{.Version}} -X github.com/ygelfand/echolocal/internal/layout.GitCommit={{.Commit}} -X github.com/ygelfand/echolocal/internal/layout.BuildDate={{.Date}}
 
 archives:
   - formats: ["binary"]

--- a/Makefile
+++ b/Makefile
@@ -198,12 +198,14 @@ release-dev: ## Publish this working tree to the dev channel, without pushing an
 	@command -v gh >/dev/null || { echo "needs the gh CLI: brew install gh"; exit 1; }
 	@command -v goreleaser >/dev/null || { echo "needs goreleaser: brew install goreleaser"; exit 1; }
 	VERSION=$(VERSION) goreleaser release --snapshot --clean
-	@for f in dist/echoctl_*/echoctl; do \
+	@for f in dist/echoctl_*/echoctl dist/echoctl_*/echoctl.exe; do \
+		[ -f "$$f" ] || continue; \
 		d=$$(basename $$(dirname $$f)); \
 		os=$$(echo $$d | cut -d_ -f2); \
 		arch=$$(echo $$d | cut -d_ -f3); \
 		if [ "$$arch" = amd64 ]; then arch=x86_64; fi; \
-		cp "$$f" "dist/echolocal_$${os}_$${arch}"; \
+		ext=$${f##*.}; [ "$$ext" = exe ] && ext=.exe || ext=; \
+		cp "$$f" "dist/echolocal_$${os}_$${arch}$${ext}"; \
 	done
 	@$(MAKE) --no-print-directory manifest VERSION=$(VERSION) FROM=$(RELEASES)/download/dev PAGE=$(RELEASES)/tag/dev
 	@gh release view dev >/dev/null 2>&1 || \

--- a/internal/host/installer/models.go
+++ b/internal/host/installer/models.go
@@ -2,7 +2,7 @@ package installer
 
 import (
 	"fmt"
-	"path/filepath"
+	"path"
 
 	"github.com/ygelfand/echolocal/internal/host/assets"
 	"github.com/ygelfand/echolocal/internal/layout"
@@ -30,9 +30,9 @@ func installModels(r *run) (string, bool, error) {
 
 	var written, kept int
 	for _, m := range models {
-		path := filepath.Join(layout.ModelDir, m.ID+".tflite")
+		modelPath := path.Join(layout.ModelDir, m.ID+".tflite")
 
-		have, err := r.d.Exists(path)
+		have, err := r.d.Exists(modelPath)
 		if err != nil {
 			return "", false, err
 		}
@@ -43,10 +43,10 @@ func installModels(r *run) (string, bool, error) {
 
 		// The manifest carries the phrase and the window the engine reads it with, so it is written
 		// first: a model without one falls back to defaults that are only right by coincidence.
-		if err := r.d.WriteFile(filepath.Join(layout.ModelDir, m.ID+".json"), m.Manifest, 0o644); err != nil {
+		if err := r.d.WriteFile(path.Join(layout.ModelDir, m.ID+".json"), m.Manifest, 0o644); err != nil {
 			return "", false, err
 		}
-		if err := r.d.WriteFile(path, m.Model, 0o644); err != nil {
+		if err := r.d.WriteFile(modelPath, m.Model, 0o644); err != nil {
 			return "", false, err
 		}
 		written++

--- a/internal/layout/free_unix.go
+++ b/internal/layout/free_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package layout
+
+import "syscall"
+
+// Free is the space left on the filesystem holding path, in bytes.
+func Free(path string) (int64, error) {
+	var fs syscall.Statfs_t
+	if err := syscall.Statfs(path, &fs); err != nil {
+		return 0, err
+	}
+	return int64(fs.Bavail) * int64(fs.Bsize), nil
+}

--- a/internal/layout/free_windows.go
+++ b/internal/layout/free_windows.go
@@ -1,0 +1,17 @@
+package layout
+
+import "golang.org/x/sys/windows"
+
+// Free is the space left on the filesystem holding path, in bytes.
+func Free(path string) (int64, error) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, err
+	}
+
+	var available uint64
+	if err := windows.GetDiskFreeSpaceEx(pathPtr, &available, nil, nil); err != nil {
+		return 0, err
+	}
+	return int64(available), nil
+}

--- a/internal/layout/layout.go
+++ b/internal/layout/layout.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"syscall"
 )
 
 // Where echod and its state live. /system is read-only once installed, so anything written
@@ -111,15 +110,6 @@ const ModelDir = StateDir + "/models"
 
 // RecordingDir holds the kept turn audio, one WAV and one metadata file per turn, named by turn id.
 const RecordingDir = StateDir + "/recordings"
-
-// Free is the space left on the filesystem holding path, in bytes.
-func Free(path string) (int64, error) {
-	var fs syscall.Statfs_t
-	if err := syscall.Statfs(path, &fs); err != nil {
-		return 0, err
-	}
-	return int64(fs.Bavail) * int64(fs.Bsize), nil
-}
 
 // MAC normalizes an address into the form Home Assistant compares against, and reports "" for
 // anything that would not identify a device. idme writes twelve hex digits with no separators.


### PR DESCRIPTION
Hi! I did a bit of work to make your tool usable for Windows users to ease my own explorations, so I figured I'd contribute it back if you're interested.

The tool basically Just Worked - I only had to implement the free-space check in a Windows-friendly way, and ensure paths that the tool pushed to the device via `adb` used Posix-friendly path separators.

Everything else is just build infra to ensure publish the Windows binaries as part of your existing release process.

Cheers, this was fun to use on my own Dots :)