### PR TITLE
Advertise the Bluetooth proxy as an iBeacon

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Music can duck under a wake word, and resumes. Also supports white-noise generat
 **Bluetooth proxy.** BLE advertisements forwarded to Home Assistant, so the Dot extends your
 Bluetooth and can be used in integrations like [bermuda](https://github.com/agittins/bermuda).
 While the proxy is enabled, the Dot also advertises as an iBeacon with UUID
-`9c5fa6f1-91c4-4f56-bb9f-d92acfd9d40b`, major `1`, and a minor matching the last octet of its IPv4
-address. The beacon stops when the proxy is disabled and updates after the Dot's address changes.
-This supports tools such as [BLE Positioning System](https://github.com/Hogster/BPS), which use the
-physical positions of BLE receivers to locate tracked devices.
+`9c5fa6f1-91c4-4f56-bb9f-d92acfd9d40b`, major `1`, and a minor derived from the final two bytes of
+its factory MAC address. The beacon stops when the proxy is disabled. This supports tools such as
+[BLE Positioning System](https://github.com/Hogster/BPS), which use the physical positions of BLE
+receivers to locate tracked devices.
 
 **Lux sensor.** The board carries an ambient light sensor that Amazon appears to have left unused.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Music can duck under a wake word, and resumes. Also supports white-noise generat
 
 **Bluetooth proxy.** BLE advertisements forwarded to Home Assistant, so the Dot extends your
 Bluetooth and can be used in integrations like [bermuda](https://github.com/agittins/bermuda).
+While the proxy is enabled, the Dot also advertises as an iBeacon with UUID
+`9c5fa6f1-91c4-4f56-bb9f-d92acfd9d40b`, major `1`, and a minor matching the last octet of its IPv4
+address. The beacon stops when the proxy is disabled and updates after the Dot's address changes.
+This supports tools such as [BLE Positioning System](https://github.com/Hogster/BPS), which use the
+physical positions of BLE receivers to locate tracked devices.
 
 **Lux sensor.** The board carries an ambient light sensor that Amazon appears to have left unused.
 

--- a/internal/boot/hardware.go
+++ b/internal/boot/hardware.go
@@ -17,9 +17,9 @@ func name() string {
 		}
 	}
 
-	b, err := os.ReadFile(layout.MACPath)
+	mac, err := layout.FactoryMAC()
 	if err != nil {
 		return layout.DefaultName
 	}
-	return layout.NameFromMAC(string(b))
+	return layout.NameFromMAC(mac)
 }

--- a/internal/feature/api/api.go
+++ b/internal/feature/api/api.go
@@ -62,7 +62,7 @@ func (a *API) Start(context.Context) error {
 	if err != nil {
 		return err
 	}
-	mac, err := macAddress()
+	mac, err := layout.FactoryMAC()
 	if err != nil {
 		return err
 	}
@@ -212,19 +212,4 @@ func writePSK(path string, k esphome.PSK) error {
 		return err
 	}
 	return os.WriteFile(path, []byte(k.String()+"\n"), 0o600)
-}
-
-// macAddress is how Home Assistant recognises the device, and it refuses one whose address is not
-// the address it registered. So there is no stand-in: without an address there is nothing to
-// announce, and announcing the wrong one costs the pairing.
-func macAddress() (string, error) {
-	b, err := os.ReadFile(layout.MACPath)
-	if err != nil {
-		return "", fmt.Errorf("reading the device address: %w", err)
-	}
-	mac := layout.MAC(string(b))
-	if mac == "" {
-		return "", fmt.Errorf("%s holds %q, which is not an address", layout.MACPath, strings.TrimSpace(string(b)))
-	}
-	return mac, nil
 }

--- a/internal/feature/bluetooth/beacon.go
+++ b/internal/feature/bluetooth/beacon.go
@@ -1,0 +1,55 @@
+package bluetooth
+
+import (
+	"encoding/binary"
+	"net"
+)
+
+const (
+	flagsDataType        = 0x01
+	generalDiscoverable  = 0x02
+	brEDRNotSupported    = 0x04
+	manufacturerDataType = 0xff
+	appleCompanyID       = 0x004c
+	iBeaconType          = 0x02
+	iBeaconPayloadLength = 0x15
+	iBeaconMajor         = 1
+	iBeaconMeasuredPower = -59
+)
+
+// This randomly assigned UUID identifies EchoLocal receivers. BPS distinguishes individual
+// receivers by the complete UUID, major, and minor tuple.
+var iBeaconUUID = [16]byte{
+	0x9c, 0x5f, 0xa6, 0xf1, 0x91, 0xc4, 0x4f, 0x56,
+	0xbb, 0x9f, 0xd9, 0x2a, 0xcf, 0xd9, 0xd4, 0x0b,
+}
+
+// beaconAdvertisement uses the last octet of the first IPv4 address as the iBeacon minor. It
+// returns nil and -1 until an IPv4 address is available.
+func beaconAdvertisement(addresses []net.IP) ([]byte, int) {
+	minor := -1
+	for _, address := range addresses {
+		if ipv4 := address.To4(); ipv4 != nil {
+			minor = int(ipv4[3])
+			break
+		}
+	}
+	if minor < 0 {
+		return nil, minor
+	}
+
+	advertisement := []byte{
+		0x02, flagsDataType, generalDiscoverable | brEDRNotSupported,
+	}
+	manufacturerLength := len(advertisement)
+	advertisement = append(advertisement, 0, manufacturerDataType)
+	advertisement = binary.LittleEndian.AppendUint16(advertisement, appleCompanyID)
+	advertisement = append(advertisement, iBeaconType, iBeaconPayloadLength)
+	advertisement = append(advertisement, iBeaconUUID[:]...)
+	advertisement = binary.BigEndian.AppendUint16(advertisement, iBeaconMajor)
+	advertisement = binary.BigEndian.AppendUint16(advertisement, uint16(minor))
+	measuredPower := int8(iBeaconMeasuredPower)
+	advertisement = append(advertisement, byte(measuredPower))
+	advertisement[manufacturerLength] = byte(len(advertisement) - manufacturerLength - 1)
+	return advertisement, minor
+}

--- a/internal/feature/bluetooth/beacon.go
+++ b/internal/feature/bluetooth/beacon.go
@@ -2,7 +2,6 @@ package bluetooth
 
 import (
 	"encoding/binary"
-	"net"
 )
 
 const (
@@ -24,18 +23,10 @@ var iBeaconUUID = [16]byte{
 	0xbb, 0x9f, 0xd9, 0x2a, 0xcf, 0xd9, 0xd4, 0x0b,
 }
 
-// beaconAdvertisement uses the last octet of the first IPv4 address as the iBeacon minor. It
-// returns nil and -1 until an IPv4 address is available.
-func beaconAdvertisement(addresses []net.IP) ([]byte, int) {
-	minor := -1
-	for _, address := range addresses {
-		if ipv4 := address.To4(); ipv4 != nil {
-			minor = int(ipv4[3])
-			break
-		}
-	}
-	if minor < 0 {
-		return nil, minor
+// beaconAdvertisement formats an iBeacon advertisement for minor.
+func beaconAdvertisement(minor int) []byte {
+	if minor < 0 || minor > 0xffff {
+		return nil
 	}
 
 	advertisement := []byte{
@@ -51,5 +42,5 @@ func beaconAdvertisement(addresses []net.IP) ([]byte, int) {
 	measuredPower := int8(iBeaconMeasuredPower)
 	advertisement = append(advertisement, byte(measuredPower))
 	advertisement[manufacturerLength] = byte(len(advertisement) - manufacturerLength - 1)
-	return advertisement, minor
+	return advertisement
 }

--- a/internal/feature/bluetooth/bluetooth.go
+++ b/internal/feature/bluetooth/bluetooth.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ygelfand/echolocal/internal/component"
 	"github.com/ygelfand/echolocal/internal/config"
 	"github.com/ygelfand/echolocal/internal/hardware/ble"
+	"github.com/ygelfand/echolocal/internal/hardware/metrics"
 	"github.com/ygelfand/echolocal/internal/lib/safe"
 )
 
@@ -26,8 +27,9 @@ func init() {
 
 const (
 	// batch is how many reports go in one message, and hold how long to wait for them.
-	batch = 16
-	hold  = 250 * time.Millisecond
+	batch       = 16
+	hold        = 250 * time.Millisecond
+	addressPoll = 10 * time.Second
 
 	// queued is how many reports may wait for Home Assistant. Past this they are dropped: the radio
 	// must never wait on the network, or the controller's own queue overflows and the driver starts
@@ -40,24 +42,32 @@ const bluetoothFeatures = esphome.BluetoothPassiveScan |
 	esphome.BluetoothRawAdvertisements |
 	esphome.BluetoothStateAndMode
 
+type beaconState struct {
+	advertisement []byte
+	minor         int
+}
+
 // bluetooth carries what the radio hears to Home Assistant. The switch says whether the radio may
 // run at all, and the subscription whether anyone is reading.
 //
-// Three goroutines, deliberately: the radio's reader only ever hands a report to a channel, a sender
-// batches and writes them, and a third starts and stops the radio. Handlers run on the connection's
-// goroutine, and HCI commands wait on the controller, so doing that work inline stops the connection
-// answering anything at all.
+// Separate goroutines read reports, deliver batches, watch the address used by the beacon, and tune
+// the radio. Handlers run on the connection's goroutine, and HCI commands wait on the controller, so
+// doing that work inline stops the connection answering anything at all.
 type Proxy struct {
 	proxy  *esphome.BluetoothProxy
 	radio  *ble.Radio
 	enable *esphome.Switch
 
-	wanted  chan struct{}
-	reports chan ble.Advertisement
-	dropped atomic.Uint64
+	wanted        chan struct{}
+	refreshBeacon chan struct{}
+	beacons       chan beaconState
+	reports       chan ble.Advertisement
+	dropped       atomic.Uint64
 
 	mu     sync.Mutex
 	active bool
+	// minor is the IPv4 suffix in the running iBeacon, or -1 when none is running.
+	minor int
 }
 
 var (
@@ -72,10 +82,13 @@ func Get() *Proxy {
 
 func build() *Proxy {
 	b := &Proxy{
-		proxy:   &esphome.BluetoothProxy{},
-		radio:   ble.Get(),
-		wanted:  make(chan struct{}, 1),
-		reports: make(chan ble.Advertisement, queued),
+		proxy:         &esphome.BluetoothProxy{},
+		radio:         ble.Get(),
+		wanted:        make(chan struct{}, 1),
+		refreshBeacon: make(chan struct{}, 1),
+		beacons:       make(chan beaconState, 1),
+		reports:       make(chan ble.Advertisement, queued),
+		minor:         -1,
 		enable: &esphome.Switch{
 			Base: esphome.Base{
 				ObjectID: "bluetooth_proxy",
@@ -97,6 +110,7 @@ func build() *Proxy {
 			return
 		}
 		b.apply()
+		b.refreshAddress()
 
 		// What the device advertises has changed, and that is only read when a client connects.
 		component.Reconnect.Emit(struct{}{})
@@ -104,6 +118,7 @@ func build() *Proxy {
 
 	safe.Go("ble radio", b.settle)
 	safe.Go("ble reports", b.deliver)
+	safe.Go("ble address", b.watchAddress)
 	return b
 }
 
@@ -144,30 +159,71 @@ func (b *Proxy) apply() {
 	}
 }
 
-func (b *Proxy) settle() {
-	for range b.wanted {
-		b.tune()
+func (b *Proxy) refreshAddress() {
+	select {
+	case b.refreshBeacon <- struct{}{}:
+	default:
 	}
 }
 
-// tune starts or stops the radio to match what is wanted, and reports which. A change of mode is a
-// restart: the scan type is fixed when scanning begins.
-func (b *Proxy) tune() {
+func (b *Proxy) watchAddress() {
+	tick := time.NewTicker(addressPoll)
+	defer tick.Stop()
+	last := -2
+	for {
+		state := beaconState{minor: -1}
+		if b.Enabled() {
+			state.advertisement, state.minor = beaconAdvertisement(metrics.Addresses())
+		}
+		if state.minor != last {
+			b.beacons <- state
+			last = state.minor
+		}
+		select {
+		case <-b.refreshBeacon:
+		case <-tick.C:
+		}
+	}
+}
+
+// settle serializes radio changes on one goroutine. Requests react immediately to proxy state, and
+// address updates carry a new iBeacon payload without doing network discovery here.
+func (b *Proxy) settle() {
+	beacon := beaconState{minor: -1}
+	for {
+		select {
+		case <-b.wanted:
+		case beacon = <-b.beacons:
+		}
+		b.tune(beacon)
+	}
+}
+
+// tune starts or stops the radio to match what is wanted, and reports which. A change of scan mode or
+// beacon minor is a restart: both are fixed when the controller starts.
+func (b *Proxy) tune(beacon beaconState) {
+	enabled := b.Enabled()
 	// Home Assistant keeps its requested scan mode while the proxy reconnects. Reporting NONE until
 	// it subscribes makes that requested/current mismatch look like a broken scanner, so subscription
 	// controls delivery below rather than whether the radio scans.
-	want := b.Enabled()
+	scan := enabled
+	if !enabled {
+		beacon = beaconState{minor: -1}
+	}
+	want := scan || len(beacon.advertisement) != 0
 	active := b.proxy.Active()
 
 	b.mu.Lock()
-	settled := want == b.radio.Scanning() && (!want || active == b.active)
+	settled := want == b.radio.Running() && scan == b.radio.Scanning() &&
+		(!scan || active == b.active) && beacon.minor == b.minor
 	b.active = active
+	b.minor = beacon.minor
 	b.mu.Unlock()
 
 	if settled {
 		return
 	}
-	if b.radio.Scanning() {
+	if b.radio.Running() {
 		b.radio.Stop()
 	}
 	if !want {
@@ -175,13 +231,20 @@ func (b *Proxy) tune() {
 		return
 	}
 
-	if err := b.radio.Start(active, b.found); err != nil {
-		slog.Error("ble scan failed to start", "err", err)
-		_ = b.proxy.Report(esphome.ScannerFailed)
+	if err := b.radio.Start(scan, active, beacon.advertisement, b.found); err != nil {
+		slog.Error("ble radio failed to start", "err", err)
+		if scan {
+			_ = b.proxy.Report(esphome.ScannerFailed)
+		}
 		return
 	}
-	slog.Info("ble scanning", "active", active)
-	_ = b.proxy.Report(esphome.ScannerRunning)
+	if len(beacon.advertisement) != 0 {
+		slog.Info("ble iBeacon advertising", "minor", beacon.minor)
+	}
+	if scan {
+		slog.Info("ble scanning", "active", active)
+		_ = b.proxy.Report(esphome.ScannerRunning)
+	}
 }
 
 // found runs on the radio's reader. It must not block: anything slow here stalls the reader, and the

--- a/internal/feature/bluetooth/bluetooth.go
+++ b/internal/feature/bluetooth/bluetooth.go
@@ -4,7 +4,9 @@ package bluetooth
 
 import (
 	"context"
+	"encoding/binary"
 	"log/slog"
+	"net"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -17,7 +19,7 @@ import (
 	"github.com/ygelfand/echolocal/internal/component"
 	"github.com/ygelfand/echolocal/internal/config"
 	"github.com/ygelfand/echolocal/internal/hardware/ble"
-	"github.com/ygelfand/echolocal/internal/hardware/metrics"
+	"github.com/ygelfand/echolocal/internal/layout"
 	"github.com/ygelfand/echolocal/internal/lib/safe"
 )
 
@@ -27,9 +29,8 @@ func init() {
 
 const (
 	// batch is how many reports go in one message, and hold how long to wait for them.
-	batch       = 16
-	hold        = 250 * time.Millisecond
-	addressPoll = 10 * time.Second
+	batch = 16
+	hold  = 250 * time.Millisecond
 
 	// queued is how many reports may wait for Home Assistant. Past this they are dropped: the radio
 	// must never wait on the network, or the controller's own queue overflows and the driver starts
@@ -50,24 +51,21 @@ type beaconState struct {
 // bluetooth carries what the radio hears to Home Assistant. The switch says whether the radio may
 // run at all, and the subscription whether anyone is reading.
 //
-// Separate goroutines read reports, deliver batches, watch the address used by the beacon, and tune
-// the radio. Handlers run on the connection's goroutine, and HCI commands wait on the controller, so
-// doing that work inline stops the connection answering anything at all.
+// Separate goroutines read reports, deliver batches, and tune the radio. Handlers run on the
+// connection's goroutine, and HCI commands wait on the controller, so doing that work inline stops
+// the connection answering anything at all.
 type Proxy struct {
 	proxy  *esphome.BluetoothProxy
 	radio  *ble.Radio
 	enable *esphome.Switch
+	beacon beaconState
 
-	wanted        chan struct{}
-	refreshBeacon chan struct{}
-	beacons       chan beaconState
-	reports       chan ble.Advertisement
-	dropped       atomic.Uint64
+	wanted  chan struct{}
+	reports chan ble.Advertisement
+	dropped atomic.Uint64
 
 	mu     sync.Mutex
 	active bool
-	// minor is the IPv4 suffix in the running iBeacon, or -1 when none is running.
-	minor int
 }
 
 var (
@@ -81,14 +79,14 @@ func Get() *Proxy {
 }
 
 func build() *Proxy {
+	mac, _ := layout.FactoryMAC()
+	minor := beaconMinor(mac)
 	b := &Proxy{
-		proxy:         &esphome.BluetoothProxy{},
-		radio:         ble.Get(),
-		wanted:        make(chan struct{}, 1),
-		refreshBeacon: make(chan struct{}, 1),
-		beacons:       make(chan beaconState, 1),
-		reports:       make(chan ble.Advertisement, queued),
-		minor:         -1,
+		proxy:   &esphome.BluetoothProxy{},
+		radio:   ble.Get(),
+		beacon:  beaconState{advertisement: beaconAdvertisement(minor), minor: minor},
+		wanted:  make(chan struct{}, 1),
+		reports: make(chan ble.Advertisement, queued),
 		enable: &esphome.Switch{
 			Base: esphome.Base{
 				ObjectID: "bluetooth_proxy",
@@ -110,7 +108,6 @@ func build() *Proxy {
 			return
 		}
 		b.apply()
-		b.refreshAddress()
 
 		// What the device advertises has changed, and that is only read when a client connects.
 		component.Reconnect.Emit(struct{}{})
@@ -118,8 +115,16 @@ func build() *Proxy {
 
 	safe.Go("ble radio", b.settle)
 	safe.Go("ble reports", b.deliver)
-	safe.Go("ble address", b.watchAddress)
+	b.apply()
 	return b
+}
+
+func beaconMinor(mac string) int {
+	address, err := net.ParseMAC(mac)
+	if err != nil || len(address) != 6 {
+		return -1
+	}
+	return int(binary.BigEndian.Uint16(address[4:]))
 }
 
 func (b *Proxy) Name() string { return "bluetooth proxy" }
@@ -159,48 +164,17 @@ func (b *Proxy) apply() {
 	}
 }
 
-func (b *Proxy) refreshAddress() {
-	select {
-	case b.refreshBeacon <- struct{}{}:
-	default:
-	}
-}
-
-func (b *Proxy) watchAddress() {
-	tick := time.NewTicker(addressPoll)
-	defer tick.Stop()
-	last := -2
-	for {
-		state := beaconState{minor: -1}
-		if b.Enabled() {
-			state.advertisement, state.minor = beaconAdvertisement(metrics.Addresses())
-		}
-		if state.minor != last {
-			b.beacons <- state
-			last = state.minor
-		}
-		select {
-		case <-b.refreshBeacon:
-		case <-tick.C:
-		}
-	}
-}
-
 // settle serializes radio changes on one goroutine. Requests react immediately to proxy state, and
-// address updates carry a new iBeacon payload without doing network discovery here.
+// the iBeacon payload is fixed from the factory MAC.
 func (b *Proxy) settle() {
-	beacon := beaconState{minor: -1}
 	for {
-		select {
-		case <-b.wanted:
-		case beacon = <-b.beacons:
-		}
-		b.tune(beacon)
+		<-b.wanted
+		b.tune(b.beacon)
 	}
 }
 
 // tune starts or stops the radio to match what is wanted, and reports which. A change of scan mode or
-// beacon minor is a restart: both are fixed when the controller starts.
+// scan activity is a restart: both scanning and advertising are fixed when the controller starts.
 func (b *Proxy) tune(beacon beaconState) {
 	enabled := b.Enabled()
 	// Home Assistant keeps its requested scan mode while the proxy reconnects. Reporting NONE until
@@ -215,9 +189,8 @@ func (b *Proxy) tune(beacon beaconState) {
 
 	b.mu.Lock()
 	settled := want == b.radio.Running() && scan == b.radio.Scanning() &&
-		(!scan || active == b.active) && beacon.minor == b.minor
+		(!scan || active == b.active)
 	b.active = active
-	b.minor = beacon.minor
 	b.mu.Unlock()
 
 	if settled {

--- a/internal/feature/bluetooth/bluetooth.go
+++ b/internal/feature/bluetooth/bluetooth.go
@@ -153,7 +153,10 @@ func (b *Proxy) settle() {
 // tune starts or stops the radio to match what is wanted, and reports which. A change of mode is a
 // restart: the scan type is fixed when scanning begins.
 func (b *Proxy) tune() {
-	want := b.Enabled() && b.proxy.Subscribed()
+	// Home Assistant keeps its requested scan mode while the proxy reconnects. Reporting NONE until
+	// it subscribes makes that requested/current mismatch look like a broken scanner, so subscription
+	// controls delivery below rather than whether the radio scans.
+	want := b.Enabled()
 	active := b.proxy.Active()
 
 	b.mu.Lock()
@@ -184,6 +187,11 @@ func (b *Proxy) tune() {
 // found runs on the radio's reader. It must not block: anything slow here stalls the reader, and the
 // controller's queue overflows into the kernel log.
 func (b *Proxy) found(a ble.Advertisement) {
+	// The radio stays up to preserve its Home Assistant scan state, but reports have nowhere to go
+	// before a client subscribes and would only fill the queue.
+	if !b.proxy.Subscribed() {
+		return
+	}
 	select {
 	case b.reports <- a:
 	default:

--- a/internal/feature/bluetooth/bluetooth.go
+++ b/internal/feature/bluetooth/bluetooth.go
@@ -167,15 +167,13 @@ func (b *Proxy) apply() {
 // settle serializes radio changes on one goroutine. Requests react immediately to proxy state, and
 // the iBeacon payload is fixed from the factory MAC.
 func (b *Proxy) settle() {
-	for {
-		<-b.wanted
-		b.tune(b.beacon)
-	}
+	settleRadio(b.wanted, func() bool { return b.tune(b.beacon) }, time.After)
 }
 
 // tune starts or stops the radio to match what is wanted, and reports which. A change of scan mode or
 // scan activity is a restart: both scanning and advertising are fixed when the controller starts.
-func (b *Proxy) tune(beacon beaconState) {
+// It reports whether the requested state was reached; failures are retried by settle.
+func (b *Proxy) tune(beacon beaconState) bool {
 	enabled := b.Enabled()
 	// Home Assistant keeps its requested scan mode while the proxy reconnects. Reporting NONE until
 	// it subscribes makes that requested/current mismatch look like a broken scanner, so subscription
@@ -194,14 +192,14 @@ func (b *Proxy) tune(beacon beaconState) {
 	b.mu.Unlock()
 
 	if settled {
-		return
+		return true
 	}
 	if b.radio.Running() {
 		b.radio.Stop()
 	}
 	if !want {
 		_ = b.proxy.Report(esphome.ScannerStopped)
-		return
+		return true
 	}
 
 	if err := b.radio.Start(scan, active, beacon.advertisement, b.found); err != nil {
@@ -209,7 +207,7 @@ func (b *Proxy) tune(beacon beaconState) {
 		if scan {
 			_ = b.proxy.Report(esphome.ScannerFailed)
 		}
-		return
+		return false
 	}
 	if len(beacon.advertisement) != 0 {
 		slog.Info("ble iBeacon advertising", "minor", beacon.minor)
@@ -218,6 +216,7 @@ func (b *Proxy) tune(beacon beaconState) {
 		slog.Info("ble scanning", "active", active)
 		_ = b.proxy.Report(esphome.ScannerRunning)
 	}
+	return true
 }
 
 // found runs on the radio's reader. It must not block: anything slow here stalls the reader, and the

--- a/internal/feature/bluetooth/bluetooth_test.go
+++ b/internal/feature/bluetooth/bluetooth_test.go
@@ -1,35 +1,36 @@
 package bluetooth
 
 import (
-	"net"
 	"slices"
 	"testing"
 )
 
 func TestBeaconAdvertisement(t *testing.T) {
-	got, minor := beaconAdvertisement([]net.IP{
-		net.ParseIP("fd00::1"),
-		net.ParseIP("192.168.1.42"),
-	})
+	got := beaconAdvertisement(0xbeef)
 	want := []byte{
 		0x02, 0x01, 0x06,
 		0x1a, 0xff, 0x4c, 0x00, 0x02, 0x15,
 		0x9c, 0x5f, 0xa6, 0xf1, 0x91, 0xc4, 0x4f, 0x56,
 		0xbb, 0x9f, 0xd9, 0x2a, 0xcf, 0xd9, 0xd4, 0x0b,
-		0x00, 0x01, 0x00, 0x2a, 0xc5,
+		0x00, 0x01, 0xbe, 0xef, 0xc5,
 	}
 
-	if minor != 42 {
-		t.Errorf("minor = %d, want 42", minor)
-	}
 	if !slices.Equal(got, want) {
 		t.Errorf("advertisement = %x, want %x", got, want)
 	}
 }
 
-func TestBeaconAdvertisementNeedsIPv4(t *testing.T) {
-	got, minor := beaconAdvertisement([]net.IP{net.ParseIP("fd00::1")})
-	if got != nil || minor != -1 {
-		t.Errorf("advertisement = %x, minor = %d; want nil, -1", got, minor)
+func TestBeaconAdvertisementRejectsInvalidMinor(t *testing.T) {
+	if got := beaconAdvertisement(-1); got != nil {
+		t.Errorf("advertisement = %x, want nil", got)
+	}
+}
+
+func TestBeaconMinor(t *testing.T) {
+	if got := beaconMinor("74:c2:46:12:be:ef"); got != 0xbeef {
+		t.Errorf("minor = %d, want %d", got, 0xbeef)
+	}
+	if got := beaconMinor("not a MAC"); got != -1 {
+		t.Errorf("minor = %d, want -1", got)
 	}
 }

--- a/internal/feature/bluetooth/bluetooth_test.go
+++ b/internal/feature/bluetooth/bluetooth_test.go
@@ -1,0 +1,35 @@
+package bluetooth
+
+import (
+	"net"
+	"slices"
+	"testing"
+)
+
+func TestBeaconAdvertisement(t *testing.T) {
+	got, minor := beaconAdvertisement([]net.IP{
+		net.ParseIP("fd00::1"),
+		net.ParseIP("192.168.1.42"),
+	})
+	want := []byte{
+		0x02, 0x01, 0x06,
+		0x1a, 0xff, 0x4c, 0x00, 0x02, 0x15,
+		0x9c, 0x5f, 0xa6, 0xf1, 0x91, 0xc4, 0x4f, 0x56,
+		0xbb, 0x9f, 0xd9, 0x2a, 0xcf, 0xd9, 0xd4, 0x0b,
+		0x00, 0x01, 0x00, 0x2a, 0xc5,
+	}
+
+	if minor != 42 {
+		t.Errorf("minor = %d, want 42", minor)
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("advertisement = %x, want %x", got, want)
+	}
+}
+
+func TestBeaconAdvertisementNeedsIPv4(t *testing.T) {
+	got, minor := beaconAdvertisement([]net.IP{net.ParseIP("fd00::1")})
+	if got != nil || minor != -1 {
+		t.Errorf("advertisement = %x, minor = %d; want nil, -1", got, minor)
+	}
+}

--- a/internal/feature/bluetooth/retry.go
+++ b/internal/feature/bluetooth/retry.go
@@ -1,0 +1,31 @@
+package bluetooth
+
+import "time"
+
+const (
+	radioRetryInitial = time.Second
+	radioRetryMax     = 30 * time.Second
+)
+
+// settleRadio applies each requested state and retries failures with bounded backoff. A new request
+// interrupts the wait and restarts from the shortest delay.
+func settleRadio(wanted <-chan struct{}, tune func() bool, after func(time.Duration) <-chan time.Time) {
+	for range wanted {
+		wait := radioRetryInitial
+		for !tune() {
+			select {
+			case _, ok := <-wanted:
+				if !ok {
+					return
+				}
+				wait = radioRetryInitial
+			case <-after(wait):
+				if next := wait * 2; next < radioRetryMax {
+					wait = next
+				} else {
+					wait = radioRetryMax
+				}
+			}
+		}
+	}
+}

--- a/internal/feature/bluetooth/retry_test.go
+++ b/internal/feature/bluetooth/retry_test.go
@@ -1,0 +1,118 @@
+package bluetooth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSettleRadioRetriesWithBoundedBackoff(t *testing.T) {
+	wanted := make(chan struct{}, 1)
+	ticks := make(chan time.Time)
+	delays := make(chan time.Duration)
+	attempts := make(chan int)
+	exited := make(chan struct{})
+	count := 0
+
+	go func() {
+		settleRadio(wanted, func() bool {
+			count++
+			attempts <- count
+			return count == 8
+		}, func(delay time.Duration) <-chan time.Time {
+			delays <- delay
+			return ticks
+		})
+		close(exited)
+	}()
+
+	wanted <- struct{}{}
+	wantDelays := []time.Duration{
+		time.Second,
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+		16 * time.Second,
+		30 * time.Second,
+		30 * time.Second,
+	}
+	for attempt, wantDelay := range wantDelays {
+		if got := receive(t, attempts); got != attempt+1 {
+			t.Fatalf("attempt = %d, want %d", got, attempt+1)
+		}
+		if got := receive(t, delays); got != wantDelay {
+			t.Fatalf("delay = %s, want %s", got, wantDelay)
+		}
+		ticks <- time.Now()
+	}
+	if got := receive(t, attempts); got != 8 {
+		t.Fatalf("attempt = %d, want 8", got)
+	}
+
+	close(wanted)
+	select {
+	case <-exited:
+	case <-time.After(time.Second):
+		t.Fatal("settler did not exit")
+	}
+}
+
+func TestSettleRadioNewRequestResetsBackoff(t *testing.T) {
+	wanted := make(chan struct{}, 1)
+	ticks := make(chan time.Time)
+	delays := make(chan time.Duration)
+	attempts := make(chan int)
+	exited := make(chan struct{})
+	count := 0
+
+	go func() {
+		settleRadio(wanted, func() bool {
+			count++
+			attempts <- count
+			return count == 3
+		}, func(delay time.Duration) <-chan time.Time {
+			delays <- delay
+			return ticks
+		})
+		close(exited)
+	}()
+
+	wanted <- struct{}{}
+	if got := receive(t, attempts); got != 1 {
+		t.Fatalf("attempt = %d, want 1", got)
+	}
+	if got := receive(t, delays); got != radioRetryInitial {
+		t.Fatalf("delay = %s, want %s", got, radioRetryInitial)
+	}
+
+	wanted <- struct{}{}
+	if got := receive(t, attempts); got != 2 {
+		t.Fatalf("attempt = %d, want 2", got)
+	}
+	if got := receive(t, delays); got != radioRetryInitial {
+		t.Fatalf("delay = %s, want reset to %s", got, radioRetryInitial)
+	}
+
+	ticks <- time.Now()
+	if got := receive(t, attempts); got != 3 {
+		t.Fatalf("attempt = %d, want 3", got)
+	}
+
+	close(wanted)
+	select {
+	case <-exited:
+	case <-time.After(time.Second):
+		t.Fatal("settler did not exit")
+	}
+}
+
+func receive[T any](t *testing.T, ch <-chan T) T {
+	t.Helper()
+	select {
+	case value := <-ch:
+		return value
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+		var zero T
+		return zero
+	}
+}

--- a/internal/feature/sendspin/session.go
+++ b/internal/feature/sendspin/session.go
@@ -55,6 +55,7 @@ func newSession(conn *websocket.Conn, o *out, bg *speaker.Arbiter, name string, 
 			Codec: f.Codec, Channels: f.Channels, SampleRate: f.SampleRate, BitDepth: f.BitDepth,
 		})
 	}
+	mac, _ := layout.FactoryMAC()
 
 	client := protocol.NewClientFromConn(protocol.Config{
 		Name: name,
@@ -65,7 +66,7 @@ func newSession(conn *websocket.Conn, o *out, bg *speaker.Arbiter, name string, 
 		SupportedRoles: []string{"player@v1"},
 
 		// The factory mac: survives a reinstall, a rename and a new address.
-		ClientID: layout.MAC(layout.Idme("mac_addr")),
+		ClientID: mac,
 		DeviceInfo: protocol.DeviceInfo{
 			ProductName:     layout.Model,
 			Manufacturer:    layout.Manufacturer,

--- a/internal/hardware/ble/ble.go
+++ b/internal/hardware/ble/ble.go
@@ -22,16 +22,20 @@ const (
 	evtLEMeta           = 0x3E
 	leAdvertisingReport = 0x02
 
-	cmdReset        = 0x0C03
-	cmdLEScanParams = 0x200B
-	cmdLEScanEnable = 0x200C
+	cmdReset               = 0x0C03
+	cmdLEAdvertisingParams = 0x2006
+	cmdLEAdvertisingData   = 0x2008
+	cmdLEAdvertisingEnable = 0x200A
+	cmdLEScanParams        = 0x200B
+	cmdLEScanEnable        = 0x200C
 )
 
 // How much of the time the radio listens, in units of 0.625 ms: 18.75 ms out of every 200 ms. Wifi
 // and Bluetooth share one antenna here, so a window equal to the interval never gives it back.
 const (
-	scanInterval = 320
-	scanWindow   = 30
+	scanInterval        = 320
+	scanWindow          = 30
+	advertisingInterval = 1600
 )
 
 // Advertisement is one LE advertising report.
@@ -56,6 +60,7 @@ type Radio struct {
 	mu       sync.Mutex
 	fd       int
 	open     bool
+	scanning bool
 	stop     context.CancelFunc
 	finished chan struct{}
 
@@ -77,6 +82,13 @@ func Get() *Radio {
 func (r *Radio) Scanning() bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	return r.scanning
+}
+
+// Running reports whether the controller is open for scanning or advertising.
+func (r *Radio) Running() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.open
 }
 
@@ -87,9 +99,10 @@ func (r *Radio) Reports() uint64 {
 	return r.reports
 }
 
-// Start opens the controller and scans until Stop. Reports arrive on the reader's goroutine. Active
-// asks for scan responses, which transmits rather than only listening.
-func (r *Radio) Start(active bool, found func(Advertisement)) error {
+// Start opens the controller until Stop. Reports arrive on the reader's goroutine when scan is true.
+// Active asks for scan responses, which transmits rather than only listening. Advertisement is raw
+// advertising data; nil disables advertising.
+func (r *Radio) Start(scan, active bool, advertisement []byte, found func(Advertisement)) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -108,7 +121,7 @@ func (r *Radio) Start(active bool, found func(Advertisement)) error {
 	}
 	r.fd = fd
 
-	if err := r.begin(active); err != nil {
+	if err := r.begin(scan, active, advertisement); err != nil {
 		_ = syscall.Close(fd)
 		r.fd = -1
 		return err
@@ -116,13 +129,13 @@ func (r *Radio) Start(active bool, found func(Advertisement)) error {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	r.stop, r.finished, r.open = cancel, make(chan struct{}), true
+	r.scanning = scan
 
 	go r.read(ctx, found)
-	slog.Info("ble scanning")
 	return nil
 }
 
-// Stop ends the scan and closes the node.
+// Stop ends scanning and advertising and closes the node.
 func (r *Radio) Stop() {
 	r.mu.Lock()
 	if !r.open {
@@ -131,12 +144,14 @@ func (r *Radio) Stop() {
 	}
 	stop, done, fd := r.stop, r.finished, r.fd
 	r.open = false
+	r.scanning = false
 	r.mu.Unlock()
 
 	stop()
 	<-done
 
 	_ = command(fd, cmdLEScanEnable, []byte{0x00, 0x00})
+	_ = command(fd, cmdLEAdvertisingEnable, []byte{0x00})
 	_ = syscall.Close(fd)
 
 	r.mu.Lock()
@@ -145,27 +160,60 @@ func (r *Radio) Stop() {
 	slog.Info("ble stopped")
 }
 
-// begin resets the controller and starts scanning. Held with mu.
-func (r *Radio) begin(active bool) error {
-	scan := make([]byte, 7)
-	if active {
-		scan[0] = 0x01
+// begin resets and configures the controller. Held with mu.
+func (r *Radio) begin(scanning, active bool, advertisement []byte) error {
+	if err := r.send("reset", cmdReset, nil); err != nil {
+		return err
 	}
-	binary.LittleEndian.PutUint16(scan[1:], scanInterval)
-	binary.LittleEndian.PutUint16(scan[3:], scanWindow)
-
-	for _, step := range []struct {
-		name   string
-		opcode uint16
-		params []byte
-	}{
-		{"reset", cmdReset, nil},
-		{"scan parameters", cmdLEScanParams, scan},
-		{"scan enable", cmdLEScanEnable, []byte{0x01, 0x00}},
-	} {
-		if err := command(r.fd, step.opcode, step.params); err != nil {
-			return fmt.Errorf("ble: %s: %w", step.name, err)
+	// This MTK controller can scan and advertise together, but only when scanning is enabled first.
+	// Enabling advertising first leaves the subsequent scan command waiting indefinitely.
+	if scanning {
+		scan := make([]byte, 7)
+		if active {
+			scan[0] = 0x01
 		}
+		binary.LittleEndian.PutUint16(scan[1:], scanInterval)
+		binary.LittleEndian.PutUint16(scan[3:], scanWindow)
+
+		if err := r.send("scan parameters", cmdLEScanParams, scan); err != nil {
+			return err
+		}
+		if err := r.send("scan enable", cmdLEScanEnable, []byte{0x01, 0x00}); err != nil {
+			return err
+		}
+	}
+	if len(advertisement) != 0 {
+		return r.advertise(advertisement)
+	}
+	return nil
+}
+
+func (r *Radio) advertise(advertisement []byte) error {
+	if len(advertisement) > 31 {
+		return errors.New("ble: advertising data exceeds 31 bytes")
+	}
+	params := make([]byte, 15)
+	binary.LittleEndian.PutUint16(params[0:], advertisingInterval)
+	binary.LittleEndian.PutUint16(params[2:], advertisingInterval)
+	params[4] = 0x03 // ADV_NONCONN_IND
+	params[13] = 0x07
+
+	data := make([]byte, 32)
+	data[0] = byte(len(advertisement))
+	copy(data[1:], advertisement)
+
+	if err := r.send("advertising parameters", cmdLEAdvertisingParams, params); err != nil {
+		return err
+	}
+	if err := r.send("advertising data", cmdLEAdvertisingData, data); err != nil {
+		return err
+	}
+	return r.send("advertising enable", cmdLEAdvertisingEnable, []byte{0x01})
+}
+
+func (r *Radio) send(name string, opcode uint16, params []byte) error {
+	if err := command(r.fd, opcode, params); err != nil {
+		return fmt.Errorf("ble: %s: %w", name, err)
 	}
 	return nil
 }

--- a/internal/hardware/ble/ble.go
+++ b/internal/hardware/ble/ble.go
@@ -245,7 +245,8 @@ func (r *Radio) read(ctx context.Context, found func(Advertisement), held []byte
 		held, err = r.parse(append(held, buf[:n]...), found)
 		if err != nil {
 			slog.Error("ble event framing failed", "err", err)
-			return
+			held = nil
+			continue
 		}
 	}
 }

--- a/internal/hardware/ble/ble.go
+++ b/internal/hardware/ble/ble.go
@@ -16,11 +16,6 @@ const Node = "/dev/stpbt"
 
 const (
 	h4Command = 0x01
-	h4Event   = 0x04
-
-	evtCommandComplete  = 0x0E
-	evtLEMeta           = 0x3E
-	leAdvertisingReport = 0x02
 
 	cmdReset               = 0x0C03
 	cmdLEAdvertisingParams = 0x2006
@@ -62,7 +57,10 @@ type Radio struct {
 	open     bool
 	scanning bool
 	stop     context.CancelFunc
-	finished chan struct{}
+	// finished is both the reader's completion signal and its handoff of an unfinished H4 event.
+	finished chan []byte
+	// held carries an unfinished H4 event between synchronous startup commands.
+	held []byte
 
 	reports uint64
 }
@@ -124,14 +122,17 @@ func (r *Radio) Start(scan, active bool, advertisement []byte, found func(Advert
 	if err := r.begin(scan, active, advertisement); err != nil {
 		_ = syscall.Close(fd)
 		r.fd = -1
+		r.held = nil
 		return err
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	r.stop, r.finished, r.open = cancel, make(chan struct{}), true
+	r.stop, r.finished, r.open = cancel, make(chan []byte, 1), true
 	r.scanning = scan
+	held := r.held
+	r.held = nil
 
-	go r.read(ctx, found)
+	go r.read(ctx, found, held, r.finished)
 	return nil
 }
 
@@ -148,10 +149,10 @@ func (r *Radio) Stop() {
 	r.mu.Unlock()
 
 	stop()
-	<-done
+	held := <-done
 
-	_ = command(fd, cmdLEScanEnable, []byte{0x00, 0x00})
-	_ = command(fd, cmdLEAdvertisingEnable, []byte{0x00})
+	held, _ = command(fd, held, cmdLEScanEnable, []byte{0x00, 0x00})
+	_, _ = command(fd, held, cmdLEAdvertisingEnable, []byte{0x00})
 	_ = syscall.Close(fd)
 
 	r.mu.Lock()
@@ -212,18 +213,19 @@ func (r *Radio) advertise(advertisement []byte) error {
 }
 
 func (r *Radio) send(name string, opcode uint16, params []byte) error {
-	if err := command(r.fd, opcode, params); err != nil {
+	var err error
+	r.held, err = command(r.fd, r.held, opcode, params)
+	if err != nil {
 		return fmt.Errorf("ble: %s: %w", name, err)
 	}
 	return nil
 }
 
-func (r *Radio) read(ctx context.Context, found func(Advertisement)) {
-	defer close(r.finished)
+func (r *Radio) read(ctx context.Context, found func(Advertisement), held []byte, finished chan<- []byte) {
+	defer func() { finished <- held }()
 
 	// The driver refuses a read larger than its own buffer, and an HCI event is at most 258 bytes.
 	buf := make([]byte, 512)
-	var held []byte
 
 	for ctx.Err() == nil {
 		n, err := syscall.Read(r.fd, buf)
@@ -240,30 +242,32 @@ func (r *Radio) read(ctx context.Context, found func(Advertisement)) {
 			continue
 		}
 
-		held = r.parse(append(held, buf[:n]...), found)
+		held, err = r.parse(append(held, buf[:n]...), found)
+		if err != nil {
+			slog.Error("ble event framing failed", "err", err)
+			return
+		}
 	}
 }
 
 // parse takes whole packets off the front and returns the remainder. A read carries as many as the
 // controller had ready, and the last can be cut short.
-func (r *Radio) parse(b []byte, found func(Advertisement)) []byte {
-	for len(b) >= 3 {
-		if b[0] != h4Event {
-			return nil
+func (r *Radio) parse(b []byte, found func(Advertisement)) ([]byte, error) {
+	for {
+		event, remainder, ok, err := nextEvent(b)
+		if err != nil {
+			return nil, err
 		}
-		size := 3 + int(b[2])
-		if len(b) < size {
-			break
+		if !ok {
+			return append([]byte(nil), remainder...), nil
 		}
 
-		if b[1] == evtLEMeta {
+		if event[1] == evtLEMeta {
 			r.reports++
-			reports(b[3:size], found)
+			reports(event[3:], found)
 		}
-		b = b[size:]
+		b = remainder
 	}
-
-	return append([]byte(nil), b...)
 }
 
 // reports walks an LE Meta event: event type, address type, address, data length, data, RSSI.
@@ -293,7 +297,7 @@ func reports(p []byte, found func(Advertisement)) {
 }
 
 // command writes one HCI command and waits for its Command Complete.
-func command(fd int, opcode uint16, params []byte) error {
+func command(fd int, held []byte, opcode uint16, params []byte) ([]byte, error) {
 	pkt := make([]byte, 4, 4+len(params))
 	pkt[0] = h4Command
 	binary.LittleEndian.PutUint16(pkt[1:], opcode)
@@ -301,7 +305,7 @@ func command(fd int, opcode uint16, params []byte) error {
 	pkt = append(pkt, params...)
 
 	if _, err := syscall.Write(fd, pkt); err != nil {
-		return err
+		return held, err
 	}
 
 	buf := make([]byte, 512)
@@ -311,16 +315,20 @@ func command(fd int, opcode uint16, params []byte) error {
 			if errors.Is(err, syscall.EINTR) {
 				continue
 			}
-			return err
+			return held, err
 		}
-		if n >= 7 && buf[0] == h4Event && buf[1] == evtCommandComplete {
-			if binary.LittleEndian.Uint16(buf[4:]) != opcode {
-				continue
-			}
-			if status := buf[6]; status != 0 {
-				return fmt.Errorf("status 0x%02x", status)
-			}
-			return nil
+		if n == 0 {
+			continue
+		}
+
+		held = append(held, buf[:n]...)
+		var complete bool
+		held, complete, err = commandResult(held, opcode)
+		if err != nil {
+			return held, err
+		}
+		if complete {
+			return held, nil
 		}
 	}
 }

--- a/internal/hardware/ble/ble_test.go
+++ b/internal/hardware/ble/ble_test.go
@@ -1,0 +1,123 @@
+package ble
+
+import (
+	"encoding/binary"
+	"slices"
+	"testing"
+)
+
+func TestCommandResultFindsBatchedCompletion(t *testing.T) {
+	const opcode = 0x200a
+	report := []byte{h4Event, evtLEMeta, 2, leAdvertisingReport, 0}
+	completion := commandComplete(opcode, 0)
+	batch := append(report, completion...)
+
+	remainder, complete, err := commandResult(batch, opcode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !complete {
+		t.Fatal("command did not complete")
+	}
+	if len(remainder) != 0 {
+		t.Errorf("remainder = %x, want empty", remainder)
+	}
+}
+
+func TestCommandResultHoldsSplitEvent(t *testing.T) {
+	const opcode = 0x200a
+	completion := commandComplete(opcode, 0)
+	first := completion[:5]
+
+	remainder, complete, err := commandResult(first, opcode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if complete {
+		t.Fatal("partial command completed")
+	}
+	if !slices.Equal(remainder, first) {
+		t.Errorf("remainder = %x, want %x", remainder, first)
+	}
+
+	remainder, complete, err = commandResult(append(remainder, completion[5:]...), opcode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !complete {
+		t.Fatal("command did not complete after remainder")
+	}
+	if len(remainder) != 0 {
+		t.Errorf("remainder = %x, want empty", remainder)
+	}
+}
+
+func TestCommandResultReturnsTrailingPartialEvent(t *testing.T) {
+	const opcode = 0x200a
+	completion := commandComplete(opcode, 0)
+	report := []byte{h4Event, evtLEMeta, 2, leAdvertisingReport, 0}
+	batch := append(completion, report[:4]...)
+
+	remainder, complete, err := commandResult(batch, opcode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !complete {
+		t.Fatal("command did not complete")
+	}
+	if !slices.Equal(remainder, report[:4]) {
+		t.Errorf("remainder = %x, want %x", remainder, report[:4])
+	}
+
+	event, remainder, ok, err := nextEvent(append(remainder, report[4:]...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || !slices.Equal(event, report) || len(remainder) != 0 {
+		t.Errorf("event = %x, remainder = %x, ok = %t", event, remainder, ok)
+	}
+}
+
+func TestCommandResultReturnsStatus(t *testing.T) {
+	const opcode = 0x200a
+	_, complete, err := commandResult(commandComplete(opcode, 0x0c), opcode)
+	if !complete {
+		t.Fatal("command did not complete")
+	}
+	if err == nil || err.Error() != "status 0x0c" {
+		t.Errorf("error = %v, want status 0x0c", err)
+	}
+}
+
+func TestCommandResultReturnsCommandStatusError(t *testing.T) {
+	const opcode = 0x200a
+	event := []byte{h4Event, evtCommandStatus, 4, 0x0c, 1, 0, 0}
+	binary.LittleEndian.PutUint16(event[5:], opcode)
+
+	_, complete, err := commandResult(event, opcode)
+	if !complete {
+		t.Fatal("command did not complete")
+	}
+	if err == nil || err.Error() != "status 0x0c" {
+		t.Errorf("error = %v, want status 0x0c", err)
+	}
+}
+
+func TestCommandResultRejectsMalformedEvent(t *testing.T) {
+	const opcode = 0x200a
+	batch := append([]byte{0xff}, commandComplete(opcode, 0)...)
+
+	_, complete, err := commandResult(batch, opcode)
+	if complete {
+		t.Fatal("malformed stream completed")
+	}
+	if err == nil {
+		t.Fatal("malformed stream returned no error")
+	}
+}
+
+func commandComplete(opcode uint16, status byte) []byte {
+	event := []byte{h4Event, evtCommandComplete, 4, 1, 0, 0, status}
+	binary.LittleEndian.PutUint16(event[4:], opcode)
+	return event
+}

--- a/internal/hardware/ble/events.go
+++ b/internal/hardware/ble/events.go
@@ -1,0 +1,69 @@
+package ble
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+const (
+	h4Event = 0x04
+
+	evtCommandComplete  = 0x0E
+	evtCommandStatus    = 0x0F
+	evtLEMeta           = 0x3E
+	leAdvertisingReport = 0x02
+)
+
+// nextEvent removes one complete H4 event from the front. Remainder is the partial packet to hold,
+// or nil when the stream is malformed.
+func nextEvent(b []byte) (event, remainder []byte, ok bool, err error) {
+	if len(b) < 3 {
+		return nil, b, false, nil
+	}
+	if b[0] != h4Event {
+		return nil, nil, false, fmt.Errorf("unexpected H4 packet type 0x%02x", b[0])
+	}
+	size := 3 + int(b[2])
+	if len(b) < size {
+		return nil, b, false, nil
+	}
+	return b[:size], b[size:], true, nil
+}
+
+// commandResult consumes complete events until it finds the matching Command Complete.
+func commandResult(b []byte, opcode uint16) (remainder []byte, complete bool, err error) {
+	for {
+		event, rest, ok, err := nextEvent(b)
+		if err != nil {
+			return nil, false, err
+		}
+		if !ok {
+			return append([]byte(nil), rest...), false, nil
+		}
+		b = rest
+
+		switch event[1] {
+		case evtCommandComplete:
+			if len(event) < 7 {
+				return nil, false, fmt.Errorf("short Command Complete event: %x", event)
+			}
+			if binary.LittleEndian.Uint16(event[4:]) != opcode {
+				continue
+			}
+			if status := event[6]; status != 0 {
+				return append([]byte(nil), b...), true, fmt.Errorf("status 0x%02x", status)
+			}
+			return append([]byte(nil), b...), true, nil
+		case evtCommandStatus:
+			if len(event) < 7 {
+				return nil, false, fmt.Errorf("short Command Status event: %x", event)
+			}
+			if binary.LittleEndian.Uint16(event[5:]) != opcode {
+				continue
+			}
+			if status := event[3]; status != 0 {
+				return append([]byte(nil), b...), true, fmt.Errorf("status 0x%02x", status)
+			}
+		}
+	}
+}

--- a/internal/layout/layout.go
+++ b/internal/layout/layout.go
@@ -3,6 +3,7 @@
 package layout
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -134,6 +135,19 @@ func MAC(raw string) string {
 		mac.WriteString(s[i : i+2])
 	}
 	return mac.String()
+}
+
+// FactoryMAC reads and normalizes the immutable address recorded for the Wi-Fi device.
+func FactoryMAC() (string, error) {
+	raw, err := os.ReadFile(MACPath)
+	if err != nil {
+		return "", fmt.Errorf("reading the factory MAC: %w", err)
+	}
+	mac := MAC(string(raw))
+	if mac == "" {
+		return "", fmt.Errorf("%s holds %q, which is not an address", MACPath, strings.TrimSpace(string(raw)))
+	}
+	return mac, nil
 }
 
 // NameFromMAC builds the fallback display name, unique per device.


### PR DESCRIPTION
## Summary

This PR makes `echod` emit a BLE iBeacon for use in BPS or other triangulation-based tools.
The iBeacon uses a custom UUID so `echolocal` installs are identifiable, and it sets the `minor` field of the iBeacon to a value derived from the MAC address of the device.

Since advertising and scanning use the same radio, the radio integration/listeners/senders needed enhancements to 
* better handling waiting for command completion
* handle events that get logically split across buffer reads
* handle transient radio reboots/startup failures

The MAC address was repeatedly calculated across a few areas of the `echod` codebase, so I took an opportunity to centralize that so all callsites are consistent.

The four new commits

* push down the MAC calculation
* change the iBeacon to use the MAC
* handle split/multi-command buffer reads
* enable retries during radio startup

Fixes #6