### PR TITLE
fix: rearm follow-up deadline on VAD speech start

### DIFF
--- a/internal/feature/voice/conversation.go
+++ b/internal/feature/voice/conversation.go
@@ -84,6 +84,7 @@ const (
 	evPending                      // a turn held back for the last one to close has waited long enough
 	evPlaying                      // the reply has audio, so the pipeline owes nothing more
 	evContinue                     // Home Assistant wants the answer to a question it just asked
+	evSpeaking                     // VAD detected speech has started
 )
 
 type event struct {
@@ -300,6 +301,11 @@ func (c *conversation) handle(e event) {
 	switch e.kind {
 	case evStart:
 		c.start(nextTurn{slot: e.slot})
+
+	case evSpeaking:
+		if c.followUp && c.phase == phaseListening {
+			c.arm(wakeword.MaxListen(c.slot))
+		}
 
 	case evContinue:
 		// The pipeline asked a question. Its answer is owed after the reply has been spoken, so this
@@ -736,6 +742,8 @@ func (c *conversation) pipeline(e esphome.PipelineEvent) {
 	switch e.Type {
 	case api.VoiceAssistantEvent_VOICE_ASSISTANT_STT_END:
 		c.post(event{kind: evHeard, text: e.Data["text"]})
+	case api.VoiceAssistantEvent_VOICE_ASSISTANT_STT_VAD_START:
+		c.post(event{kind: evSpeaking})
 	case api.VoiceAssistantEvent_VOICE_ASSISTANT_STT_VAD_END:
 		c.post(event{kind: evHeard})
 	case api.VoiceAssistantEvent_VOICE_ASSISTANT_INTENT_PROGRESS:


### PR DESCRIPTION
## Summary

During a follow-up turn, the short `follow_up_time` deadline (e.g. 2 seconds) is not
reset when the user actually starts speaking. If the utterance takes longer than
`follow_up_time` to complete, the device closes the pipeline mid-speech, causing a
`ConnectionResetError` on the Home Assistant side and a dropped turn on the device.

This PR handles `VOICE_ASSISTANT_STT_VAD_START` in the pipeline event switch: when VAD
detects speech during a follow-up listening phase, the deadline is rearmed with
`MaxListen` (15s), giving the user the full listening window to finish their sentence.

## Changes

- Add `evSpeaking` event kind
- Handle `evSpeaking` in `handle()`: if in a follow-up listening phase, rearm with `MaxListen`
- Map `VOICE_ASSISTANT_STT_VAD_START` → `evSpeaking` in `pipeline()`

## Test plan

- Set `follow_up_time` to 2 seconds
- Trigger a voice command, get a response, then speak a follow-up that takes longer than 2 seconds
- Without this fix: pipeline closes mid-utterance, HA logs `ConnectionResetError`
- With this fix: deadline extends to 15s on speech start, follow-up completes normally