### PR TITLE
Sendspin: hold the room to the server clock while a stream plays

### DIFF
--- a/internal/feature/sendspin/output.go
+++ b/internal/feature/sendspin/output.go
@@ -23,6 +23,31 @@ import (
 // reaching this means a timestamp we cannot believe rather than a server sending too much.
 const holdMax = 60 * speaker.Rate
 
+// Drift correction. The anchor maps server time to output frames at the nominal rate, but the speaker's
+// clock is not the server's: measured on device, one Dot ran about 200 ppm fast and pulled ahead of
+// another by 12 ms a minute. So every render period the frame being heard is compared with the frame
+// the server clock says should be, the error is smoothed, and one frame is dropped or repeated per
+// period while the smoothed error is outside the band. A frame is 21 us; the spec's own suggestion,
+// and inaudible at the handful per second a real drift needs.
+//
+// driftGain is the smoothing: at 47 periods a second, a time constant of about a second, enough to
+// take the scheduling jitter out of when a period happens to be rendered. driftBand is half a
+// millisecond either side, inside the spec's 1 ms floor with room for the noise that remains.
+//
+// An error past snapBand is not drift but a misplaced anchor, most often a period's worth of phase
+// between the write counter and the card at the moment the stream started, or an underrun that moved
+// the counter on without playing anything. That is put right in one step of silence or one skip, which
+// the spec allows on a start, and the fine correction takes it from there.
+//
+// tailFrames is the hardware tail in frames: the write counter is that far ahead of what is heard, and
+// the anchor was laid in terms of what is heard.
+const (
+	driftGain  = 0.02
+	driftBand  = speaker.Rate / 2000
+	snapBand   = speaker.Rate / 100
+	tailFrames = int64(speaker.HardwareTail * speaker.Rate / time.Second)
+)
+
 // out places this room's audio by output frame index. Arrival order cannot line two rooms up: a burst
 // of jitter on one of them shifts it against the other for good, because nothing says where the audio
 // was meant to go. The server's timestamps say, so they decide.
@@ -42,10 +67,20 @@ type out struct {
 	pcm    []int16
 
 	// The frame that carries server time at. Fixed once per stream: recomputing it per chunk would
-	// feed the sampling jitter of "what is playing now" straight back into where audio lands.
+	// feed the sampling jitter of "what is playing now" straight back into where audio lands. Drift
+	// correction nudges frame by whole frames instead, in step with the audio it moves.
 	anchored bool
 	frame    uint64
 	at       int64
+
+	// drift is the smoothed error between the frame being heard and the frame the server clock wants,
+	// in frames, positive when the room is playing early. corrected counts frames repeated (positive)
+	// or dropped (negative) to hold it.
+	drift     float64
+	corrected int64
+
+	// now stands in for the clock, so a test can hold the server's time still.
+	now func() int64
 
 	late    atomic.Int64
 	dropped atomic.Int64
@@ -178,9 +213,68 @@ func (o *out) Render(from uint64, buf []int16) {
 	if o.held || !o.ready || from < o.base {
 		return
 	}
+	o.correct(from)
 	for i := range min(len(buf), len(o.pcm)) {
 		buf[i] = scale(o.pcm[i], o.gain)
 	}
+}
+
+// correct holds the room to the server clock. Wants mu, and pcm's head at from.
+func (o *out) correct(from uint64) {
+	if !o.anchored || len(o.pcm) < 2*speaker.Channels {
+		return
+	}
+	now := o.now
+	if now == nil {
+		if o.clock == nil {
+			return
+		}
+		now = o.clock.ServerMicrosNow
+	}
+
+	// The frame the server clock says should be heard now, against the one that is: the frame being
+	// rendered less the tail it has yet to travel.
+	want := int64(o.frame) + (now()-o.at)*speaker.Rate/1e6
+	o.drift += (float64(int64(from)-tailFrames-want) - o.drift) * driftGain
+
+	switch {
+	case o.drift > snapBand:
+		n := int(o.drift)
+		o.pcm = append(make([]int16, n*speaker.Channels), o.pcm...)
+		o.frame += uint64(n)
+		o.corrected += int64(n)
+		o.drift = 0
+		slog.Info("sendspin snapped later", "ms", n*1000/speaker.Rate)
+	case o.drift < -snapBand:
+		n := min(int(-o.drift), len(o.pcm)/speaker.Channels-1)
+		o.pcm = append(o.pcm[:0], o.pcm[n*speaker.Channels:]...)
+		o.frame -= uint64(n)
+		o.corrected -= int64(n)
+		o.drift = 0
+		slog.Info("sendspin snapped earlier", "ms", n*1000/speaker.Rate)
+	case o.drift > driftBand:
+		// Early: say the first frame twice, and move the anchor with it so what arrives next lands in
+		// step with what is already queued.
+		o.pcm = append(o.pcm, o.pcm[:speaker.Channels]...)
+		copy(o.pcm[speaker.Channels:], o.pcm[:len(o.pcm)-speaker.Channels])
+		o.frame++
+		o.drift--
+		o.corrected++
+	case o.drift < -driftBand:
+		// Late: skip the first frame.
+		n := copy(o.pcm, o.pcm[speaker.Channels:])
+		o.pcm = o.pcm[:n]
+		o.frame--
+		o.drift++
+		o.corrected--
+	}
+}
+
+// drifting reports the smoothed error in frames and the frames corrected so far, for the log.
+func (o *out) drifting() (drift float64, corrected int64) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.drift, o.corrected
 }
 
 // flush drops what has not been heard yet, and the anchor with it: what comes next is a new timeline.
@@ -195,6 +289,7 @@ func (o *out) reset() {
 	o.pcm = o.pcm[:0]
 	o.base = 0
 	o.anchored = false
+	o.drift = 0
 }
 
 func (o *out) misses() (late, dropped int64) { return o.late.Load(), o.dropped.Load() }

--- a/internal/feature/sendspin/output_test.go
+++ b/internal/feature/sendspin/output_test.go
@@ -167,3 +167,108 @@ func TestFlushDropsTheAnchor(t *testing.T) {
 		t.Errorf("held %d samples, want none", len(o.pcm))
 	}
 }
+
+// ramp is audio whose frames can be told apart, so a repeated or skipped one shows.
+func ramp(n int) []int16 {
+	s := frames(n)
+	for i := range s {
+		s[i] = int16(i / speaker.Channels)
+	}
+	return s
+}
+
+// heard is the write position at which the anchor frame is the one being heard: the tail further on.
+const heard = 1000 + uint64(tailFrames)
+
+// listening anchors a room and queues a ramp from the anchor to well past the write position, as a
+// running stream has, then puts the card where the anchor frame is being heard, so that only the
+// server clock decides what the correction sees.
+func listening(t *testing.T) *out {
+	t.Helper()
+	o := anchored(t)
+	o.write(microsFor(0), ramp(int(tailFrames)+4800))
+	o.played = heard
+	return o
+}
+
+// A room whose speaker runs fast finds itself rendering frames the server clock has not reached yet.
+// The renderer should repeat frames until the two agree, moving the anchor with them.
+func TestDriftCorrectionRepeatsFramesWhenEarly(t *testing.T) {
+	o := listening(t)
+
+	// The server clock says frame 900 is due where the card is hearing 1000: a hundred frames early.
+	o.now = func() int64 { return microsFor(-100) }
+	for range 400 {
+		o.Render(heard, frames(1))
+	}
+
+	if o.corrected < 60 || o.corrected > 100 {
+		t.Fatalf("corrected %d frames, want most of 100", o.corrected)
+	}
+	if int64(o.frame) != 1000+o.corrected {
+		t.Fatalf("anchor frame %d did not move with the %d frames repeated", o.frame, o.corrected)
+	}
+	if got := len(o.pcm) / speaker.Channels; got != 4800+int(o.corrected) {
+		t.Fatalf("queue holds %d frames, want %d", got, 4800+int(o.corrected))
+	}
+	// Everything repeated is the frame at the head; the original run follows intact.
+	first := int16(heard - 1000)
+	for i := range int(o.corrected) + 1 {
+		if o.pcm[i*speaker.Channels] != first {
+			t.Fatalf("frame %d is %d, want a repeat of frame %d", i, o.pcm[i*speaker.Channels], first)
+		}
+	}
+	if o.pcm[(int(o.corrected)+1)*speaker.Channels] != first+1 {
+		t.Fatal("the original next frame did not follow the repeats")
+	}
+}
+
+func TestDriftCorrectionSkipsFramesWhenLate(t *testing.T) {
+	o := listening(t)
+
+	o.now = func() int64 { return microsFor(100) }
+	for range 400 {
+		o.Render(heard, frames(1))
+	}
+
+	if o.corrected > -60 || o.corrected < -100 {
+		t.Fatalf("corrected %d frames, want most of -100", o.corrected)
+	}
+	if int64(o.frame) != 1000+o.corrected {
+		t.Fatalf("anchor frame %d did not move with the %d frames skipped", o.frame, -o.corrected)
+	}
+	if want := int16(heard-1000) + int16(-o.corrected); o.pcm[0] != want {
+		t.Fatalf("queue head is frame %d, want %d", o.pcm[0], want)
+	}
+}
+
+// A large error at the start of a stream is a misplaced anchor, and is put right in one step of
+// silence rather than a frame at a time.
+func TestDriftCorrectionSnapsLargeErrors(t *testing.T) {
+	o := listening(t)
+	o.now = func() int64 { return microsFor(-2400) }
+	for range 800 {
+		o.Render(heard, frames(1))
+	}
+	if o.corrected < 2350 || o.corrected > 2450 {
+		t.Fatalf("corrected %d frames, want about 2400", o.corrected)
+	}
+	if o.pcm[0] != 0 || o.pcm[100*speaker.Channels] != 0 {
+		t.Fatal("the snap did not insert silence at the head")
+	}
+	if int64(o.frame) != 1000+o.corrected {
+		t.Fatalf("anchor frame %d did not move with the %d frames inserted", o.frame, o.corrected)
+	}
+}
+
+// Inside the band nothing moves: correcting jitter would be worse than the jitter.
+func TestDriftCorrectionLeavesSmallErrorsAlone(t *testing.T) {
+	o := listening(t)
+	o.now = func() int64 { return microsFor(-10) }
+	for range 400 {
+		o.Render(heard, frames(1))
+	}
+	if o.corrected != 0 || o.frame != 1000 {
+		t.Fatalf("corrected %d, frame %d", o.corrected, o.frame)
+	}
+}

--- a/internal/feature/sendspin/session.go
+++ b/internal/feature/sendspin/session.go
@@ -257,12 +257,15 @@ func (s *session) heard(chunk protocol.AudioChunk) {
 	// also how far behind the intended point the room is running.
 	if s.chunks++; s.chunks%250 == 0 {
 		late, dropped := s.out.misses()
+		drift, corrected := s.out.drifting()
 		slog.Info("sendspin ahead",
 			"queued_ms", s.out.queuedMs(),
 			"undecoded", len(s.client.AudioChunks),
 			"lead_ms", (chunk.Timestamp-s.clock.ServerMicrosNow())/1000,
 			"late", late,
-			"dropped", dropped)
+			"dropped", dropped,
+			"drift_ms", drift*1000/speaker.Rate,
+			"corrected", corrected)
 	}
 }
 


### PR DESCRIPTION
Split out of #34 as requested. This is the renderer change only; nothing here touches the transport, and it applies to the current sendspin-go client as is.

## Why

A stream is anchored once, mapping server time to output frames at the nominal rate, and the speaker's clock is never compared with the server's again. Two Dots playing the same stream here drifted apart: one ran about 200 ppm fast and pulled 12 ms a minute ahead, and its anchor was 46 ms out from the first chunk, which alone is audible between rooms. With four units the difference was easy to hear.

## What

Every render period the frame being heard (the write counter less the hardware tail) is compared with the frame the server clock says should be heard. The error is smoothed with a time constant of about a second, and while it sits outside half a millisecond one frame is repeated (early) or skipped (late), with the anchor moved by the same frame so what arrives next lands in step with what is already queued. That is the spec's suggested strategy, and at 21 us a frame it is inaudible at the handful per second a real drift needs.

An error past 10 ms is treated as a misplaced anchor rather than drift, most often a period's worth of phase between the write counter and the card at the moment the stream started, and is put right in one step of silence or one skip, which the spec allows on a start.

The `sendspin ahead` log line gains `drift_ms` and `corrected` so it can be watched on device.

## Testing

Two Dots against Music Assistant 2.11: both hold within 0.3 ms of the server clock through a stream, and the rooms are in sync by ear. Unit tests cover repeating, skipping, the snap, and the dead band. `go test ./...`, `go vet`, gofmt and the arm64 build pass.
