### PR TITLE
fix: don't double-suspend the stream retaking the speaker during a hold

### DIFF
--- a/internal/hardware/speaker/arbiter.go
+++ b/internal/hardware/speaker/arbiter.go
@@ -24,6 +24,9 @@ type Arbiter struct {
 	stack []Producer // the last is the one being heard
 	held  bool       // the driver has stood the background down
 	duck  bool
+	// hold is the producer the hold stood down, so a retake by it during the same hold is not
+	// suspended a second time.
+	hold Producer
 }
 
 // Backgrounds is this driver's arbiter, made on first use. Per driver, not per package: echoctl
@@ -46,6 +49,7 @@ func (a *Arbiter) Took(p Producer) {
 	stood := a.top()
 	a.stack = append(a.stack, p)
 	held, duck := a.held, a.duck
+	hold := a.hold
 	a.mu.Unlock()
 
 	// Already down if the driver holds the lot, and suspending twice would need undoing twice.
@@ -54,7 +58,11 @@ func (a *Arbiter) Took(p Producer) {
 		stood.Suspend()
 	}
 	p.Duck(duck)
-	if held {
+	// The hold stood at most one producer down — the one being heard when it began, or none if the
+	// speaker was silent. A retake by that same producer is already held, so suspending it again would
+	// leave a resume outstanding; anyone else joining mid-hold is stood down here so it cannot play
+	// over the claim.
+	if held && p != hold {
 		p.Suspend()
 	}
 }
@@ -85,6 +93,9 @@ func (a *Arbiter) Suspend() {
 	}
 	a.held = true
 	p := a.top()
+	if p != nil {
+		a.hold = p
+	}
 	a.mu.Unlock()
 
 	if p != nil {
@@ -99,6 +110,7 @@ func (a *Arbiter) Resume() {
 		return
 	}
 	a.held = false
+	a.hold = nil
 	p := a.top()
 	a.mu.Unlock()
 

--- a/internal/hardware/speaker/arbiter_test.go
+++ b/internal/hardware/speaker/arbiter_test.go
@@ -216,3 +216,55 @@ func TestStartingTwiceLeavesOneEntry(t *testing.T) {
 		t.Error("a duplicate entry outlived the producer that finished")
 	}
 }
+
+// The media player is one producer that replaces its own track, so every noise or media switch is the
+// same stream taking the speaker again. When that happens while the driver holds it, the hold already
+// stood the stream down once — standing it down again leaves a resume outstanding, and it waits on a
+// gate nobody opens: playing on paper, silent in the room, until the process restarts.
+func TestAResumingTrackRetakingTheSpeakerIsNotHeldTwice(t *testing.T) {
+	a := &Arbiter{}
+	track := &producer{}
+	a.Took(track)
+
+	a.Suspend()
+	if !track.held() {
+		t.Fatal("the track ignored the driver taking the speaker")
+	}
+
+	// A track change mid-claim: the stream re-joins as itself.
+	a.Took(track)
+	if !track.held() {
+		t.Error("a track must stay stood down while the speaker is held")
+	}
+
+	a.Resume()
+	if track.held() {
+		t.Errorf("the track never came back: %d suspends, %d resumes", track.suspends, track.resumes)
+	}
+}
+
+// A sound that ends during the hold and starts again before it is over is still the producer the
+// hold stood down: stopping the noise to start another one under a claim must not leave it waiting
+// on a second suspend that one resume cannot answer.
+func TestARetakeAfterGivingBackDuringAHoldIsNotHeldTwice(t *testing.T) {
+	a := &Arbiter{}
+	track := &producer{}
+	a.Took(track)
+
+	a.Suspend()
+	if !track.held() {
+		t.Fatal("the track ignored the driver taking the speaker")
+	}
+
+	// A stop mid-claim, then a new sound before the claim ends.
+	a.Gave(track)
+	a.Took(track)
+	if !track.held() {
+		t.Error("a track must stay stood down while the speaker is held")
+	}
+
+	a.Resume()
+	if track.held() {
+		t.Errorf("the track never came back: %d suspends, %d resumes", track.suspends, track.resumes)
+	}
+}


### PR DESCRIPTION
Fixes the "media_player reports playing but no sound, silently forever" wedge (issue #38).

## Root cause

The media stream is a **single** producer that re-joins the speaker arbiter on every noise/media switch (`Stream.start` → `Arbiter.Took` with the same object; it drops itself and re-appends). When a claim takes the speaker (announcement / TTS reply), the arbiter's hold already suspends the heard producer once (`Arbiter.Suspend` → `Stream.Suspend`, holds 0→1, gate closed).

If a noise/media switch lands *while the claim is active*, `Took`'s old `if held { p.Suspend() }` suspended that same stream a **second** time (holds 1→2). The single claim-end `Resume` (holds 2→1) can never re-open the gate — `Stream.Resume` only unblocks at 0 — so generation parks permanently: the player reports *playing*, nothing is audible, and only a process restart recovers it.

## Fix

`Arbiter` now records the exact producer the hold stood down (`hold`, set in `Suspend`, cleared in `Resume`), and `Took` skips re-suspending only that identity:

```go
if held && p != hold {
    p.Suspend()
}
```

An earlier `wasHeard := a.top() == p` heuristic was reviewed and found to still double-suspend when the stream gives the speaker back mid-claim (Stop/EOF → `Gave`) and retakes before the claim ends (the stack top is then nil or another producer). Tracking the held producer's identity covers that too.

## Tests

Two regression tests in `internal/hardware/speaker/arbiter_test.go`, both verified to **fail on the base** (`2 suspends, 1 resumes` → the exact wedge) and pass with the fix:

- `TestAResumingTrackRetakingTheSpeakerIsNotHeldTwice` — retake mid-claim while still top
- `TestARetakeAfterGivingBackDuringAHoldIsNotHeldTwice` — give back mid-claim, then retake before the claim ends

## Verification

- `go test ./...` — full suite green
- `go test -race ./internal/hardware/speaker` — green
- `go vet`, `gofmt -l` — clean

Note: a full local `-race` run also trips a **pre-existing** 10-minute timeout in `internal/lib/denoise` (`quiet_test.go`, DSP-math-heavy, untouched here — same on base); CI runners are expected to pass it.


## How to reproduce

Environment: an Echo Dot 2 on EchoLocal, HA 2026.x, white noise via the `noise_layer_1` select.

1. Start white noise: set layer 1 to **White** (or any layer) — the room plays continuously, player reports *playing*.
2. Take a claim on the speaker **without stopping the noise**: call `media_player.play_media` with `announce: true` and any short audio (or `tts.speak`) to the Dot — the phrase sounds over the ducked noise.
3. **Mid-announce, while the phrase is still sounding**, switch the layer: White → **Brown**, then ~2 s later → back to **White**. (Pure color switches — never `None`/Stop; stopping mid-claim is a separate variant, see the follow-up PR.)
4. Let the phrase finish.

**Expected (fixed):** white noise audibly resumes immediately after the phrase.
**Pre-fix:** the player keeps reporting *playing* but the room is **permanently silent** (even further layer switches stay silent) until the process is restarted.
